### PR TITLE
update bson document dependency, narrow to testCompile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: "$kotlinVersion"
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: "$kotlinVersion"
 
-    compile group: 'org.mongodb', name: 'mongo-java-driver', version: '3.10.0'
+    testCompile group: 'org.mongodb', name: 'bson', version: '4.2.3'
 
     testCompile group: 'com.natpryce', name: 'hamkrest', version: '1.6.0.0'
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: "$junitVersion"


### PR DESCRIPTION
Solving #1 

Changed the dependency to mongo driver to `testCompile`. Also updated from `mongo-java-driver:3.10.0` to `bson:4.2.3` as the tests merely needed `Document`.